### PR TITLE
ci(release): build and extract chart deps before chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,31 @@ jobs:
         with:
           version: v3.14.4
 
+      - name: Add chart repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Build chart dependencies
+        run: |
+          # chart-releaser runs `helm package` on each chart, which requires
+          # every subchart declared in Chart.yaml to be present in charts/.
+          # `helm dependency build` downloads the subcharts as .tgz, but
+          # `helm package` (and `helm install`/`helm template`) only recognise
+          # unpacked chart directories — so extract every .tgz after download.
+          for chart in charts/*/; do
+            [ -f "${chart}Chart.yaml" ] || continue
+            helm dependency build "$chart"
+            if [ -d "${chart}charts" ]; then
+              (
+                cd "${chart}charts"
+                shopt -s nullglob
+                for f in *.tgz; do
+                  tar -xzf "$f" && rm -f "$f"
+                done
+              )
+            fi
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:


### PR DESCRIPTION
The release workflow failed after merging #41 with:

```
Packaging chart 'charts/go-freeradius'...
Error: found in Chart.yaml, but missing in charts/ directory: redis, mysql, mariadb, mongodb
```

Same root cause as the lint-test fix: charts with subchart dependencies
(go-freeradius pulls bitnami/redis, mysql, mariadb, mongodb) need their
dependencies resolved before \`cr package\` runs.

Fix: add two steps before chart-releaser —
1. \`helm repo add bitnami\` to register the upstream repo.
2. \`helm dependency build\` + extract each .tgz into a directory, so
   \`helm package\` can resolve them.

As a side benefit, the packaged chart .tgz that gets published now contains
the subcharts as unpacked directories, so consumers don't need to run
\`helm dependency build\` after pulling the chart.

Ref: failed run https://github.com/langazov/helm-charts/actions/runs/31409961310